### PR TITLE
Fixed mismatch between target dir and package namespace for AppRate.java

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -51,7 +51,7 @@ under the License.
     <platform name="android">
         <dependency id="org.apache.cordova.inappbrowser"/>
 
-        <source-file src="src/android/AppRate.java" target-dir="src/org/apache/cordova/apprate"/>
+        <source-file src="src/android/AppRate.java" target-dir="src/org/pushandplay/cordova/apprate"/>
 
         <config-file target="res/xml/config.xml" parent="/*">
             <feature name="AppRate">


### PR DESCRIPTION
`source-file` directive for `AppRate.java` in current `plugin.xml` states

```
<source-file src="src/android/AppRate.java" target-dir="src/org/apache/cordova/apprate"/>
```

but package namespace is

```
org.pushandplay.cordova.apprate
```

Changed `target-dir` attribute to `src/org/pushandplay/cordova/apprate`