### PR TITLE
Plugin and dependency ids fixed to new cordova plugin naming convention

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -20,7 +20,7 @@ under the License.
 -->
 
 <plugin xmlns="http://cordova.apache.org/ns/plugins/1.0"
-        id="org.pushandplay.cordova.apprate"
+        id="cordova-plugin-apprate"
         version="1.1.7">
     <name>AppRate</name>
     <description>This plugin provide the "rate this app" functionality into your Cordova/Phonegap application
@@ -36,8 +36,8 @@ under the License.
         <engine name="cordova" version=">=3.0.0"/>
     </engines>
 
-    <dependency id="org.apache.cordova.dialogs"/>
-    <dependency id="org.apache.cordova.globalization"/>
+    <dependency id="cordova-plugin-dialogs"/>
+    <dependency id="cordova-plugin-globalization"/>
 
     <js-module src="www/AppRate.js" name="AppRate">
         <clobbers target="AppRate"/>


### PR DESCRIPTION
Solves #88 and please push to npm.