### PR TITLE
Rename plugin dependencies to new naming model

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -36,8 +36,8 @@ under the License.
         <engine name="cordova" version=">=3.0.0"/>
     </engines>
 
-    <dependency id="org.apache.cordova.dialogs"/>
-    <dependency id="org.apache.cordova.globalization"/>
+    <dependency id="cordova-plugin-dialogs"/>
+    <dependency id="cordova-plugin-globalization"/>
 
     <js-module src="www/AppRate.js" name="AppRate">
         <clobbers target="AppRate"/>
@@ -49,7 +49,7 @@ under the License.
 
     <!-- android -->
     <platform name="android">
-        <dependency id="org.apache.cordova.inappbrowser"/>
+        <dependency id="cordova-plugin-inappbrowser"/>
 
         <source-file src="src/android/AppRate.java" target-dir="src/org/pushandplay/cordova/apprate"/>
 


### PR DESCRIPTION
* cordova-plugin-dialogs
* cordova-plugin-globalization
* cordova-plugin-inappbrowser (Android only)