### PR TITLE
Remove InAppBrowser dependency

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -38,7 +38,6 @@ under the License.
 
     <dependency id="cordova-plugin-dialogs"/>
     <dependency id="cordova-plugin-globalization"/>
-    <dependency id="cordova-plugin-inappbrowser"/>
 
     <js-module src="www/AppRate.js" name="AppRate">
         <clobbers target="AppRate"/>


### PR DESCRIPTION
Maybe I'm wrong but I'm not sure the InAppBrowser plugin is really used actually.
In order to use it you should override `window.open` as it is mentioned from the doc :
`window.open = cordova.InAppBrowser.open;`

Moreover, I'm not sure it is really useful to keep it as you explicitly call the system browser : 
`window.open(PREF_STORE_URL_FORMAT_IOS + this.preferences.storeAppURL.ios, '_system');`
Or use `SKStoreProductViewController` in case of the `openStoreInApp` option.

Cheers