### PR TITLE
Add deep link for app store on ios9

### DIFF
--- a/www/AppRate.js
+++ b/www/AppRate.js
@@ -33,7 +33,8 @@ AppRate = (function() {
 
   FLAG_NATIVE_CODE_SUPPORTED = /(iPhone|iPod|iPad|Android)/i.test(navigator.userAgent.toLowerCase());
 
-  PREF_STORE_URL_FORMAT_IOS = "http://itunes.apple.com/WebObjects/MZStore.woa/wa/viewContentsUserReviews?pageNumber=0&sortOrdering=1&type=Purple+Software&mt=8&id=";
+  PREF_STORE_URL_FORMAT_IOS9 = "itms-apps://itunes.apple.com/app/viewContentsUserReviews/id";
+  PREF_STORE_URL_FORMAT_IOS8 = "http://itunes.apple.com/WebObjects/MZStore.woa/wa/viewContentsUserReviews?pageNumber=0&sortOrdering=1&type=Purple+Software&mt=8&id=";
 
   counter = {
     applicationVersion: void 0,
@@ -197,12 +198,18 @@ AppRate = (function() {
 
   AppRate.navigateToAppStore = function() {
     var iOSVersion;
+    var PREF_STORE_URL_FORMAT_IOS;
     if (/(iPhone|iPod|iPad)/i.test(navigator.userAgent.toLowerCase())) {
       if (this.preferences.openStoreInApp) {
         exec(null, null, 'AppRate', 'launchAppStore', [this.preferences.storeAppURL.ios]);
       } else {
         iOSVersion = navigator.userAgent.match(/OS\s+([\d\_]+)/i)[0].replace(/_/g, '.').replace('OS ', '').split('.');
         iOSVersion = parseInt(iOSVersion[0]) + (parseInt(iOSVersion[1]) || 0) / 10;
+        if (iOSVersion < 9) {
+          PREF_STORE_URL_FORMAT_IOS = PREF_STORE_URL_FORMAT_IOS8;
+        } else {
+          PREF_STORE_URL_FORMAT_IOS = PREF_STORE_URL_FORMAT_IOS9;
+        }        
         window.open(PREF_STORE_URL_FORMAT_IOS + this.preferences.storeAppURL.ios, '_system');
       }
     } else if (/(Android)/i.test(navigator.userAgent.toLowerCase())) {


### PR DESCRIPTION
Fixes #123. Links directly to the reviews tab in the App Store app. Tested on iOS 9.3.5. I've left the existing url pattern in place for iOS8 and below.