### PR TITLE
Add support to SKStoreReviewController for In-App Reviews in iOS

### DIFF
--- a/src/ios/CDVAppRate.h
+++ b/src/ios/CDVAppRate.h
@@ -26,6 +26,10 @@
 
 - (void)getAppTitle:(CDVInvokedUrlCommand *)command;
 
-- (void)launchAppStore:(CDVInvokedUrlCommand *)command;
+- (void)launchiOSReview:(CDVInvokedUrlCommand *)command;
+
+- (void)launchAppStore:(NSString *)appId;
+
+- (void)launchInAppReview;
 
 @end

--- a/src/ios/CDVAppRate.m
+++ b/src/ios/CDVAppRate.m
@@ -24,12 +24,12 @@
 @implementation CDVAppRate
 
 - (void)getAppVersion:(CDVInvokedUrlCommand *)command {
-    [self.commandDelegate runInBackground:^{
+    	[self.commandDelegate runInBackground:^{
         NSString *versionString = [[NSBundle mainBundle] infoDictionary][@"CFBundleShortVersionString"];
         CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:versionString];
 
         [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
-    }];
+		}];
 }
 
 - (void)getAppTitle:(CDVInvokedUrlCommand *)command {

--- a/src/ios/CDVAppRate.m
+++ b/src/ios/CDVAppRate.m
@@ -15,57 +15,73 @@
  KIND, either express or implied.  See the License for the
  specific language governing permissions and limitations
  under the License.
-*/
+ */
 
 #import "CDVAppRate.h"
 #import <Cordova/CDV.h>
+#import <StoreKit/StoreKit.h>
 
 @implementation CDVAppRate
 
 - (void)getAppVersion:(CDVInvokedUrlCommand *)command {
-	[self.commandDelegate runInBackground:^{
-		NSString *versionString = [[NSBundle mainBundle] infoDictionary][@"CFBundleShortVersionString"];
-		CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:versionString];
+    [self.commandDelegate runInBackground:^{
+        NSString *versionString = [[NSBundle mainBundle] infoDictionary][@"CFBundleShortVersionString"];
+        CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:versionString];
 
-		[self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
-	}];
+        [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+    }];
 }
 
 - (void)getAppTitle:(CDVInvokedUrlCommand *)command {
-	[self.commandDelegate runInBackground:^{
-		NSString *appNameString = [[NSBundle mainBundle] infoDictionary][@"CFBundleDisplayName"];
-		CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:appNameString];
+    [self.commandDelegate runInBackground:^{
+        NSString *appNameString = [[NSBundle mainBundle] infoDictionary][@"CFBundleDisplayName"];
+        CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:appNameString];
 
-		[self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
-	}];
+        [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+    }];
 }
 
-- (void)launchAppStore:(CDVInvokedUrlCommand *)command {
-	[self.commandDelegate runInBackground:^{
-		NSString *appId = @"";
-		if ([command.arguments count] >= 1) {
-			appId = (NSString *) (command.arguments)[0];
-		}
+- (void)launchiOSReview:(CDVInvokedUrlCommand *)command {
+    if ([SKStoreReviewController class]) {
+        [self launchInAppReview];
+    } else {
+        NSString *appId = @"";
 
-		// Initialize Product View Controller
-		SKStoreProductViewController *storeProductViewController = [[SKStoreProductViewController alloc] init];
+        if ([command.arguments count] >= 1) {
+            appId = (NSString *) (command.arguments)[0];
+        }
 
-		// Configure View Controller
-		[storeProductViewController setDelegate:self];
-		[storeProductViewController loadProductWithParameters:@{SKStoreProductParameterITunesItemIdentifier : appId} completionBlock:^(BOOL result, NSError *error) {
-			if (error) {
-				NSLog(@"Error %@ with User Info %@.", error, [error userInfo]);
-			} else {
-				[UIApplication sharedApplication].networkActivityIndicatorVisible = NO;
-				[self.viewController presentViewController:storeProductViewController animated:YES completion:nil];
-			}
-		}];
-		[UIApplication sharedApplication].networkActivityIndicatorVisible = YES;
-	}];
+        [self launchAppStore:appId];
+    }
+}
+
+- (void)launchAppStore:(NSString *) appId{
+    [self.commandDelegate runInBackground:^{
+        // Initialize Product View Controller
+        SKStoreProductViewController *storeProductViewController = [[SKStoreProductViewController alloc] init];
+
+        // Configure View Controller
+        [storeProductViewController setDelegate:self];
+        [storeProductViewController loadProductWithParameters:@{SKStoreProductParameterITunesItemIdentifier : appId} completionBlock:^(BOOL result, NSError *error) {
+            if (error) {
+                NSLog(@"Error %@ with User Info %@.", error, [error userInfo]);
+            } else {
+                [UIApplication sharedApplication].networkActivityIndicatorVisible = NO;
+                [self.viewController presentViewController:storeProductViewController animated:YES completion:nil];
+            }
+        }];
+        [UIApplication sharedApplication].networkActivityIndicatorVisible = YES;
+    }];
+}
+
+- (void)launchInAppReview {
+    [self.commandDelegate runInBackground:^{
+        [SKStoreReviewController requestReview];
+    }];
 }
 
 - (void)productViewControllerDidFinish:(SKStoreProductViewController *)viewController {
-	[viewController dismissViewControllerAnimated:YES completion:nil];
+    [viewController dismissViewControllerAnimated:YES completion:nil];
 }
 
 @end

--- a/src/ios/CDVAppRate.m
+++ b/src/ios/CDVAppRate.m
@@ -42,7 +42,9 @@
 }
 
 - (void)launchiOSReview:(CDVInvokedUrlCommand *)command {
-    if ([SKStoreReviewController class]) {
+    BOOL shouldUseNativePrompt = [command.arguments[1] boolValue];
+
+    if (shouldUseNativePrompt && [SKStoreReviewController class]) {
         [self launchInAppReview];
     } else {
         NSString *appId = @"";

--- a/www/AppRate.js
+++ b/www/AppRate.js
@@ -211,7 +211,7 @@ AppRate = (function() {
     var iOSStoreUrl;
     if (/(iPhone|iPod|iPad)/i.test(navigator.userAgent.toLowerCase())) {
       if (this.preferences.openStoreInApp) {
-        exec(null, null, 'AppRate', 'launchAppStore', [this.preferences.storeAppURL.ios]);
+        exec(null, null, 'AppRate', 'launchiOSReview', [this.preferences.storeAppURL.ios]);
       } else {
         iOSVersion = navigator.userAgent.match(/OS\s+([\d\_]+)/i)[0].replace(/_/g, '.').replace('OS ', '').split('.');
         iOSVersion = parseInt(iOSVersion[0]) + (parseInt(iOSVersion[1]) || 0) / 10;


### PR DESCRIPTION
Hello everyone!

I have added support to the new in-app rating system that Apple released for iOS 10.3 or above. I thought that it would be useful to make a PR, making it available in the plugin.

This new app reviewing feature is only available in iOS 10.3 or above. There is only one limitation, you only can ask for review three times a year.

Here you have the [SKStoreReviewController API Reference](https://developer.apple.com/reference/storekit/skstorereviewcontroller) and the [iOS Human Interface Guidelines](https://developer.apple.com/ios/human-interface-guidelines/interaction/ratings-and-reviews/) about Ratings and Reviews.

All feedback is welcomed, and I hope you like this PR.
