### PR TITLE
Removing cordova as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,7 @@
     "type": "git",
     "url": "https://github.com/pushandplay/cordova-plugin-apprate"
   },
-  "dependencies": {
-    "cordova": "*"
-  },
+  "dependencies": {},
   "devDependencies": {
     "grunt": "*",
     "grunt-cordovacli": "*"

--- a/plugin.xml
+++ b/plugin.xml
@@ -19,7 +19,7 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-<plugin xmlns="http://cordova.apache.org/ns/plugins/1.0" id="cordova-plugin-apprate" version="1.3.3">
+<plugin xmlns="http://cordova.apache.org/ns/plugins/1.0" id="cordova-plugin-apprate" version="1.3.0">
     <name>AppRate</name>
     <description>This plugin provides "Rate This App" functionality to your Cordova/Phonegap application</description>
     <author email="hello@pushandplay.ru" href="http://pushandplay.ru">pushandplay</author>

--- a/plugin.xml
+++ b/plugin.xml
@@ -19,7 +19,7 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-<plugin xmlns="http://cordova.apache.org/ns/plugins/1.0" id="cordova-plugin-apprate" version="1.3.0">
+<plugin xmlns="http://cordova.apache.org/ns/plugins/1.0" id="cordova-plugin-apprate" version="1.3.3">
     <name>AppRate</name>
     <description>This plugin provides "Rate This App" functionality to your Cordova/Phonegap application</description>
     <author email="hello@pushandplay.ru" href="http://pushandplay.ru">pushandplay</author>


### PR DESCRIPTION
Removing cordova as a dependency since it is pulling in an old version of npm into the cordova project.