### PR TITLE
fix: use default locale (en) entries as fallback

### DIFF
--- a/www/locales.js
+++ b/www/locales.js
@@ -54,7 +54,8 @@ Locales = (function() {
       applicationTitle = '';
     }
     localeObject = customLocale || locales[language] || locales[language.split(/-/)[0]] || locales[LOCALE_DEFAULT];
-    localeObject.title = localeObject.title.replace(/%@/g, applicationTitle);
+  	localeObject = Object.assign({}, locales[LOCALE_DEFAULT], localeObject);	//use entries of default locale as fallback for unset entries
+	localeObject.title = localeObject.title.replace(/%@/g, applicationTitle);
     localeObject.appRatePromptTitle = (localeObject.appRatePromptTitle || '').replace(/%@/g, applicationTitle);
     localeObject.feedbackPromptTitle = (localeObject.feedbackPromptTitle || '').replace(/%@/g, applicationTitle);
     localeObject.appRatePromptMessage = (localeObject.appRatePromptMessage || '').replace(/%@/g, applicationTitle);


### PR DESCRIPTION
should close #218 and #212

if for a selected locale not all entries are set (e.g. `appRatePromptTitle` is missing) the text will be taken from the default locale (which is `en` atm).

__Notes:__
- this fix assumes that the default locale is defined with all necessary entries
- this fix can lead to using multiple languages inside of the dialogs (eg. `title` is in german and `appRatePromptTitle` is in english/default_locale)