### PR TITLE
Adding native support for windows platform rating

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,11 +47,12 @@ Makes sure all your calls to the plugin happen after the cordova `onDeviceReady`
 
 ### Simple setup and call
 
+Note: windows does not need an URL as this is done by the native code.
+
 ```javascript
 AppRate.preferences.storeAppURL = {
   ios: '<my_app_id>',
   android: 'market://details?id=<package_name>',
-  windows: 'ms-windows-store://pdp/?ProductId=<the apps Store ID>',
   blackberry: 'appworld://content/[App Id]/',
   windows8: 'ms-windows-store:Review?name=<the Package Family Name of the application>'
 };

--- a/www/AppRate.js
+++ b/www/AppRate.js
@@ -277,7 +277,7 @@ AppRate = (function() {
     } else if (/(Android)/i.test(navigator.userAgent.toLowerCase())) {
       cordova.InAppBrowser.open(this.preferences.storeAppURL.android, '_system', 'location=no');
     } else if (/(Windows|Edge)/i.test(navigator.userAgent.toLowerCase())) {
-      cordova.InAppBrowser.open(this.preferences.storeAppURL.windows, '_blank', 'location=no');
+	  Windows.Services.Store.StoreRequestHelper.sendRequestAsync(Windows.Services.Store.StoreContext.getDefault(), 16, "");
     } else if (/(BlackBerry)/i.test(navigator.userAgent.toLowerCase())) {
       cordova.InAppBrowser.open(this.preferences.storeAppURL.blackberry, '_system', 'location=no');
     } else if (/(IEMobile|Windows Phone)/i.test(navigator.userAgent.toLowerCase())) {


### PR DESCRIPTION
This small change adds support for the native UWP app rating dialog - which actually obsoletes the inappbrowser plugin for the windows platform.