### PR TITLE
Fallback to InAppBrowser if in Simulator or Testflight

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -19,15 +19,15 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-<plugin xmlns="http://cordova.apache.org/ns/plugins/1.0" id="cordova-plugin-apprate" version="1.4.0">
+<plugin xmlns="http://cordova.apache.org/ns/plugins/1.0" id="cordova-plugin-apprate" version="1.4.1">
     <name>AppRate</name>
-    <description>This plugin provides "Rate This App" functionality to your Cordova/Phonegap application</description>
+    <description>This plugin provides "Rate This App" functionality to your Cordova/Phonegap application + TestFlight Version</description>
     <author email="hello@pushandplay.ru" href="http://pushandplay.ru">pushandplay</author>
     <keywords>cordova,phonegap,AppRate,App Rate,rate,iRate,rate in iTunes,write a review,rate us,rate my application</keywords>
     <license>Apache 2.0</license>
     <info>Cross-platform AppRate plugin for Cordova / PhoneGap</info>
-    <repo>https://github.com/pushandplay/cordova-plugin-apprate.git</repo>
-    <issue>https://github.com/pushandplay/cordova-plugin-apprate/issues</issue>
+    <repo>https://github.com/brainycouchmike/cordova-plugin-apprate.git</repo>
+    <issue>https://github.com/brainycouchmike/cordova-plugin-apprate/issues</issue>
 
     <engines>
         <engine name="cordova" version=">=3.0.0"/>
@@ -36,6 +36,7 @@ under the License.
     <dependency id="cordova-plugin-dialogs"/>
     <dependency id="cordova-plugin-inappbrowser"/>
     <dependency id="cordova-plugin-nativestorage"/>
+    <dependency id="cordova-plugin-add-swift-support" version="1.7.2"/>
 
     <js-module src="www/AppRate.js" name="AppRate">
         <clobbers target="AppRate"/>
@@ -68,6 +69,7 @@ under the License.
 
         <header-file src="src/ios/CDVAppRate.h"/>
         <source-file src="src/ios/CDVAppRate.m"/>
+        <source-file src="src/ios/CDVAppRate.swift"/>
 
         <framework src="StoreKit.framework"/>
     </platform>

--- a/plugin.xml
+++ b/plugin.xml
@@ -19,7 +19,7 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-<plugin xmlns="http://cordova.apache.org/ns/plugins/1.0" id="cordova-plugin-apprate" version="1.4.1">
+<plugin xmlns="http://cordova.apache.org/ns/plugins/1.0" id="cordova-plugin-apprate" version="1.4.2">
     <name>AppRate</name>
     <description>This plugin provides "Rate This App" functionality to your Cordova/Phonegap application + TestFlight Version</description>
     <author email="hello@pushandplay.ru" href="http://pushandplay.ru">pushandplay</author>

--- a/plugin.xml
+++ b/plugin.xml
@@ -19,7 +19,7 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-<plugin xmlns="http://cordova.apache.org/ns/plugins/1.0" id="cordova-plugin-apprate" version="1.4.2">
+<plugin xmlns="http://cordova.apache.org/ns/plugins/1.0" id="cordova-plugin-apprate" version="1.4.3">
     <name>AppRate</name>
     <description>This plugin provides "Rate This App" functionality to your Cordova/Phonegap application + TestFlight Version</description>
     <author email="hello@pushandplay.ru" href="http://pushandplay.ru">pushandplay</author>

--- a/src/ios/CDVAppRate.m
+++ b/src/ios/CDVAppRate.m
@@ -20,6 +20,7 @@
 #import "CDVAppRate.h"
 #import <Cordova/CDV.h>
 #import <StoreKit/StoreKit.h>
+#import "Pulse_Community-Swift.h"
 
 @implementation CDVAppRate
 
@@ -55,6 +56,20 @@
 
         [self launchAppStore:appId];
     }
+}
+
+
+- (void)isSimulatorOrTestFlight:(CDVInvokedUrlCommand *)command {
+    SwiftAppRate *instance = [SwiftAppRate new];
+    [self.commandDelegate runInBackground:^{
+        CDVPluginResult *pluginResult = NULL;
+        if ([instance isTestFlight]) {
+            pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"true"];
+        } else {
+            pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"false"];
+        }
+        [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+    }];
 }
 
 - (void)launchAppStore:(NSString *) appId{

--- a/src/ios/CDVAppRate.swift
+++ b/src/ios/CDVAppRate.swift
@@ -13,6 +13,9 @@ class SwiftAppRate: NSObject {
 //    }
     @objc
     func isTestFlight() -> Bool {
-        return (Bundle.main.path(forResource: "embedded", ofType: "mobileprovision") != nil);
+        guard let path = Bundle.main.appStoreReceiptURL?.path else {
+            return false
+        }
+        return path.contains("CoreSimulator") || path.contains("sandboxReceipt")
     }
 }

--- a/src/ios/CDVAppRate.swift
+++ b/src/ios/CDVAppRate.swift
@@ -1,0 +1,18 @@
+//
+//  CDVAppRate.swift
+//  Pulse Community
+//
+//  Created by Pulse LTD, LLC on 10/25/18.
+//
+
+import Foundation
+
+class SwiftAppRate: NSObject {
+//    class func `new`() -> SwiftAppRate {
+//        return SwiftAppRate()
+//    }
+    @objc
+    func isTestFlight() -> Bool {
+        return (Bundle.main.path(forResource: "embedded", ofType: "mobileprovision") != nil);
+    }
+}

--- a/www/AppRate.js
+++ b/www/AppRate.js
@@ -220,6 +220,7 @@ AppRate = (function () {
     })(this));
     getIsSimulator((function (_this) {
       return function (isSimulator) {
+        isSimulator = isSimulator == "true" ? true : false;
         _this.preferences.inAppReview = _this.preferences.inAppReview && !!isSimulator;
         return _this;
       };

--- a/www/AppRate.js
+++ b/www/AppRate.js
@@ -26,10 +26,10 @@ exec = require('cordova/exec');
 
 Storage = require('./storage')
 
-AppRate = (function() {
-  var FLAG_NATIVE_CODE_SUPPORTED, LOCAL_STORAGE_COUNTER, PREF_STORE_URL_FORMAT_IOS, counter, getAppTitle, getAppVersion, promptForRatingWindowButtonClickHandler, showDialog, updateCounter;
+AppRate = (function () {
+  var FLAG_NATIVE_CODE_SUPPORTED, LOCAL_STORAGE_COUNTER, PREF_STORE_URL_FORMAT_IOS, counter, getAppTitle, getAppVersion, getIsSimulator, promptForRatingWindowButtonClickHandler, showDialog, updateCounter;
 
-  function AppRate() {}
+  function AppRate() { }
 
   LOCAL_STORAGE_COUNTER = 'counter';
   LOCAL_STORAGE_IOS_RATING = 'iosRating';
@@ -58,7 +58,7 @@ AppRate = (function() {
         break;
       case 1:
         currentBtn = localeObj.noButtonLabel;
-        if(typeof base.handleNegativeFeedback === "function") {
+        if (typeof base.handleNegativeFeedback === "function") {
           navigator.notification.confirm(localeObj.feedbackPromptMessage, promptForFeedbackWindowButtonClickHandler, localeObj.feedbackPromptTitle, [localeObj.noButtonLabel, localeObj.yesButtonLabel]);
         }
         break;
@@ -67,10 +67,10 @@ AppRate = (function() {
         navigator.notification.confirm(localeObj.message, promptForStoreRatingWindowButtonClickHandler, localeObj.title, [localeObj.cancelButtonLabel, localeObj.laterButtonLabel, localeObj.rateButtonLabel])
         break;
     }
-    return typeof base.onButtonClicked === "function" ? base.onButtonClicked(buttonIndex, currentBtn, "AppRatingPrompt") : function(){ };
+    return typeof base.onButtonClicked === "function" ? base.onButtonClicked(buttonIndex, currentBtn, "AppRatingPrompt") : function () { };
   };
 
-  promptForStoreRatingWindowButtonClickHandler = function(buttonIndex) {
+  promptForStoreRatingWindowButtonClickHandler = function (buttonIndex) {
     var base = AppRate.preferences.callbacks, currentBtn = null;
     switch (buttonIndex) {
       case 0:
@@ -91,12 +91,12 @@ AppRate = (function() {
         break;
     }
     //This is called only in case the user clicked on a button
-    typeof base.onButtonClicked === "function" ? base.onButtonClicked(buttonIndex, currentBtn, "StoreRatingPrompt") : function(){ };
+    typeof base.onButtonClicked === "function" ? base.onButtonClicked(buttonIndex, currentBtn, "StoreRatingPrompt") : function () { };
     //This one is called anyway once the process is done
-    return typeof base.done === "function" ? base.done() : function(){ };
+    return typeof base.done === "function" ? base.done() : function () { };
   };
 
-  promptForFeedbackWindowButtonClickHandler = function(buttonIndex) {
+  promptForFeedbackWindowButtonClickHandler = function (buttonIndex) {
     var base = AppRate.preferences.callbacks, currentBtn = null;
     switch (buttonIndex) {
       case 1:
@@ -109,10 +109,10 @@ AppRate = (function() {
         base.handleNegativeFeedback();
         break;
     }
-    return typeof base.onButtonClicked === "function" ? base.onButtonClicked(buttonIndex, currentBtn, "FeedbackPrompt") : function(){ };
+    return typeof base.onButtonClicked === "function" ? base.onButtonClicked(buttonIndex, currentBtn, "FeedbackPrompt") : function () { };
   };
 
-  updateCounter = function(action) {
+  updateCounter = function (action) {
     if (action == null) {
       action = 'increment';
     }
@@ -132,7 +132,7 @@ AppRate = (function() {
     return counter;
   };
 
-  updateiOSRatingData = function() {
+  updateiOSRatingData = function () {
     if (checkIfDateIsAfter(iOSRating.lastPromptDate, 365)) {
       iOSRating.timesPrompted = 0;
     }
@@ -141,20 +141,19 @@ AppRate = (function() {
     iOSRating.lastPromptDate = new Date();
 
     Storage.set(LOCAL_STORAGE_IOS_RATING, iOSRating);
-  };
+  }
 
-  showDialog = function(immediately) {
-    updateCounter();
+  showDialog = function (immediately) {
+    var base = AppRate.preferences.callbacks;
     if (counter.countdown === AppRate.preferences.usesUntilPrompt || immediately) {
       localeObj = Locales.getLocale(AppRate.preferences.useLanguage, AppRate.preferences.displayAppName, AppRate.preferences.customLocale);
 
-      if(AppRate.preferences.simpleMode) {
+      if (AppRate.preferences.simpleMode) {
         navigator.notification.confirm(localeObj.message, promptForStoreRatingWindowButtonClickHandler, localeObj.title, [localeObj.cancelButtonLabel, localeObj.laterButtonLabel, localeObj.rateButtonLabel]);
       } else {
         navigator.notification.confirm(localeObj.appRatePromptMessage, promptForAppRatingWindowButtonClickHandler, localeObj.appRatePromptTitle, [localeObj.noButtonLabel, localeObj.yesButtonLabel]);
       }
 
-      var base = AppRate.preferences.callbacks;
       if (typeof base.onRateDialogShow === "function") {
         base.onRateDialogShow(promptForStoreRatingWindowButtonClickHandler);
       }
@@ -162,7 +161,7 @@ AppRate = (function() {
     return AppRate;
   };
 
-  getAppVersion = function(successCallback, errorCallback) {
+  getAppVersion = function (successCallback, errorCallback) {
     if (FLAG_NATIVE_CODE_SUPPORTED) {
       exec(successCallback, errorCallback, 'AppRate', 'getAppVersion', []);
     } else {
@@ -171,7 +170,7 @@ AppRate = (function() {
     return AppRate;
   };
 
-  getAppTitle = function(successCallback, errorCallback) {
+  getAppTitle = function (successCallback, errorCallback) {
     if (FLAG_NATIVE_CODE_SUPPORTED) {
       exec(successCallback, errorCallback, 'AppRate', 'getAppTitle', []);
     } else {
@@ -180,7 +179,15 @@ AppRate = (function() {
     return AppRate;
   };
 
-  AppRate.init = function() {
+  getIsSimulator = function (successCallback, errorCallback) {
+    if (FLAG_NATIVE_CODE_SUPPORTED) {
+      exec(successCallback, errorCallback, 'AppRate', 'isSimulatorOrTestFlight', []);
+    } else {
+      successCallback(false); // assume we're not in a simulator or test version
+    }
+  }
+
+  AppRate.init = function () {
     AppRate.ready = Promise.all([
       Storage.get(LOCAL_STORAGE_COUNTER).then(function (storedCounter) {
         counter = storedCounter || counter
@@ -194,8 +201,8 @@ AppRate = (function() {
       })
     ])
 
-    getAppVersion((function(_this) {
-      return function(applicationVersion) {
+    getAppVersion((function (_this) {
+      return function (applicationVersion) {
         if (counter.applicationVersion !== applicationVersion) {
           counter.applicationVersion = applicationVersion;
           if (_this.preferences.promptAgainForEachNewVersion) {
@@ -205,9 +212,15 @@ AppRate = (function() {
         return _this;
       };
     })(this));
-    getAppTitle((function(_this) {
-      return function(displayAppName) {
+    getAppTitle((function (_this) {
+      return function (displayAppName) {
         _this.preferences.displayAppName = displayAppName;
+        return _this;
+      };
+    })(this));
+    getIsSimulator((function (_this) {
+      return function (isSimulator) {
+        _this.preferences.inAppReview = _this.preferences.inAppReview && !!isSimulator;
         return _this;
       };
     })(this));
@@ -239,23 +252,27 @@ AppRate = (function() {
     customLocale: null
   };
 
-  AppRate.promptForRating = function(immediately) {
-    AppRate.ready.then(function() {
+  AppRate.promptForRating = function (immediately) {
+    AppRate.ready.then(function () {
       if (immediately == null) {
         immediately = true;
       }
-
-      // see also: https://cordova.apache.org/news/2017/11/20/migrate-from-cordova-globalization-plugin.html
-      if (AppRate.preferences.useLanguage === null && window.Intl && typeof window.Intl === 'object') {
-        AppRate.preferences.useLanguage = window.navigator.language;
+      if (AppRate.preferences.useLanguage === null) {
+        navigator.globalization.getPreferredLanguage((function (_this) {
+          return function (language) {
+            _this.preferences.useLanguage = language.value;
+            return showDialog(immediately);
+          };
+        })(AppRate));
+      } else {
+        showDialog(immediately);
       }
-
-      showDialog(immediately);
+      updateCounter();
     });
     return this;
   };
 
-  AppRate.navigateToAppStore = function() {
+  AppRate.navigateToAppStore = function () {
     var iOSVersion;
     var iOSStoreUrl;
 
@@ -277,7 +294,7 @@ AppRate = (function() {
     } else if (/(Android)/i.test(navigator.userAgent.toLowerCase())) {
       cordova.InAppBrowser.open(this.preferences.storeAppURL.android, '_system', 'location=no');
     } else if (/(Windows|Edge)/i.test(navigator.userAgent.toLowerCase())) {
-	  Windows.Services.Store.StoreRequestHelper.sendRequestAsync(Windows.Services.Store.StoreContext.getDefault(), 16, "");
+      cordova.InAppBrowser.open(this.preferences.storeAppURL.windows, '_blank', 'location=no');
     } else if (/(BlackBerry)/i.test(navigator.userAgent.toLowerCase())) {
       cordova.InAppBrowser.open(this.preferences.storeAppURL.blackberry, '_system', 'location=no');
     } else if (/(IEMobile|Windows Phone)/i.test(navigator.userAgent.toLowerCase())) {

--- a/www/AppRate.js
+++ b/www/AppRate.js
@@ -221,7 +221,7 @@ AppRate = (function () {
     getIsSimulator((function (_this) {
       return function (isSimulator) {
         isSimulator = isSimulator == "true" ? true : false;
-        _this.preferences.inAppReview = _this.preferences.inAppReview && !!isSimulator;
+        _this.preferences.inAppReview = _this.preferences.inAppReview && !isSimulator;
         return _this;
       };
     })(this));


### PR DESCRIPTION
Within the Simulator and TestFlight, the InApp Review method provided by Apple, silently fails.

This update will cause the native plugin to allow fallback to InAppBrowser (which will at least bring you to the store, and say the item doesn't exist, therefore making Testing possible).