### PR TITLE
Remove inappbrowser dependency adding support to choose between inappbrowser and safariviewcontroller

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,47 @@ A plugin to provide rate this app functionality into your cordova application
 - Windows
 - Blackberry
 
+## Installation Prerequisites
+Choose your preferred browser plugin which will be used to open the store and install it:
+- https://github.com/EddyVerbruggen/cordova-plugin-safariviewcontroller
+- https://github.com/apache/cordova-plugin-inappbrowser
+
+NOTE: If you chose inappbrowser then make sure to add `openUrl: AppRate.preferences.openUrl` option to preferences if you will override the preference object. And if you chose cordova-plugin-safariviewcontroller then you must configure it with this plugin by setting:
+```javascript
+AppRate.preferences.openUrl = function (url) {
+  if (!window.SafariViewController) {
+    window.open(url, '_blank', 'location=yes');
+  }
+  else {
+    SafariViewController.isAvailable(function (available) {
+        if (available) {
+          SafariViewController.show({
+                url: url,
+                barColor: "#0000ff", // on iOS 10+ you can change the background color as well
+                controlTintColor: "#00ffff" // on iOS 10+ you can override the default tintColor
+                tintColor: "#00ffff", // should be set to same value as controlTintColor and will be a fallback on older ios
+              },
+              // this success handler will be invoked for the lifecycle events 'opened', 'loaded' and 'closed'
+              function(result) {
+                if (result.event === 'opened') {
+                  console.log('opened');
+                } else if (result.event === 'loaded') {
+                  console.log('loaded');
+                } else if (result.event === 'closed') {
+                  console.log('closed');
+                }
+              },
+              function(msg) {
+                console.log("error: " + msg);
+              })
+        } else {
+          window.open(url, '_blank', 'location=yes');
+        }
+      });
+  }
+};
+```
+
 ## Installation
 
 - From cordova plugins registry: `cordova plugin add cordova-plugin-apprate`
@@ -98,7 +139,7 @@ AppRate.preferences.customLocale = {
 };
 ```
 
-### Full setup
+### Full setup using SafariViewController
 
 ```javascript
 AppRate.preferences = {
@@ -135,6 +176,82 @@ AppRate.preferences = {
       console.log("onButtonClicked -> " + buttonIndex);
     }
   }
+};
+
+AppRate.preferences.openUrl = function (url) {
+  if (!window.SafariViewController) {
+    window.open(url, '_blank', 'location=yes');
+  }
+  else {
+    SafariViewController.isAvailable(function (available) {
+        if (available) {
+          SafariViewController.show({
+                url: url,
+                barColor: "#0000ff", // on iOS 10+ you can change the background color as well
+                controlTintColor: "#00ffff" // on iOS 10+ you can override the default tintColor
+                tintColor: "#00ffff", // should be set to same value as controlTintColor and will be a fallback on older ios
+              },
+              // this success handler will be invoked for the lifecycle events 'opened', 'loaded' and 'closed'
+              function(result) {
+                if (result.event === 'opened') {
+                  console.log('opened');
+                } else if (result.event === 'loaded') {
+                  console.log('loaded');
+                } else if (result.event === 'closed') {
+                  console.log('closed');
+                }
+              },
+              function(msg) {
+                console.log("error: " + msg);
+              })
+        } else {
+          window.open(url, '_blank', 'location=yes');
+        }
+      });
+  }
+};
+
+AppRate.promptForRating();
+```
+
+### Full setup using inappbrowser
+
+```javascript
+AppRate.preferences = {
+  displayAppName: 'My custom app title',
+  usesUntilPrompt: 5,
+  promptAgainForEachNewVersion: false,
+  inAppReview: true,
+  storeAppURL: {
+    ios: '<my_app_id>',
+    android: 'market://details?id=<package_name>',
+    windows: 'ms-windows-store://pdp/?ProductId=<the apps Store ID>',
+    blackberry: 'appworld://content/[App Id]/',
+    windows8: 'ms-windows-store:Review?name=<the Package Family Name of the application>'
+  },
+  customLocale: {
+    title: "Would you mind rating %@?",
+    message: "It won’t take more than a minute and helps to promote our app. Thanks for your support!",
+    cancelButtonLabel: "No, Thanks",
+    laterButtonLabel: "Remind Me Later",
+    rateButtonLabel: "Rate It Now",
+    yesButtonLabel: "Yes!",
+    noButtonLabel: "Not really",
+    appRatePromptTitle: 'Do you like using %@',
+    feedbackPromptTitle: 'Mind giving us some feedback?',
+  },
+  callbacks: {
+    handleNegativeFeedback: function(){
+      window.open('mailto:feedback@example.com','_system');
+    },
+    onRateDialogShow: function(callback){
+      callback(1) // cause immediate click on 'Rate Now' button
+    },
+    onButtonClicked: function(buttonIndex){
+      console.log("onButtonClicked -> " + buttonIndex);
+    }
+  },
+  openUrl: AppRate.preferences.openUrl
 };
 
 AppRate.promptForRating();

--- a/plugin.xml
+++ b/plugin.xml
@@ -34,7 +34,6 @@ under the License.
     </engines>
 
     <dependency id="cordova-plugin-dialogs"/>
-    <dependency id="cordova-plugin-inappbrowser"/>
     <dependency id="cordova-plugin-nativestorage"/>
 
     <js-module src="www/AppRate.js" name="AppRate">

--- a/www/AppRate.js
+++ b/www/AppRate.js
@@ -236,7 +236,10 @@ AppRate = (function() {
       windows8: null,
       windows: null
     },
-    customLocale: null
+    customLocale: null,
+    openUrl: function (url) {
+        cordova.InAppBrowser.open(url, '_system', 'location=no');
+    }
   };
 
   AppRate.promptForRating = function(immediately) {
@@ -272,16 +275,16 @@ AppRate = (function() {
         } else {
           iOSStoreUrl = PREF_STORE_URL_PREFIX_IOS9 + this.preferences.storeAppURL.ios + PREF_STORE_URL_POSTFIX_IOS9;
         }
-        cordova.InAppBrowser.open(iOSStoreUrl, '_system', 'location=no');
+	AppRate.preferences.openUrl(iOSStoreUrl);
       }
     } else if (/(Android)/i.test(navigator.userAgent.toLowerCase())) {
-      cordova.InAppBrowser.open(this.preferences.storeAppURL.android, '_system', 'location=no');
+      AppRate.preferences.openUrl(this.preferences.storeAppURL.android);
     } else if (/(Windows|Edge)/i.test(navigator.userAgent.toLowerCase())) {
 	  Windows.Services.Store.StoreRequestHelper.sendRequestAsync(Windows.Services.Store.StoreContext.getDefault(), 16, "");
     } else if (/(BlackBerry)/i.test(navigator.userAgent.toLowerCase())) {
-      cordova.InAppBrowser.open(this.preferences.storeAppURL.blackberry, '_system', 'location=no');
+      AppRate.preferences.openUrl(this.preferences.storeAppURL.blackberry);
     } else if (/(IEMobile|Windows Phone)/i.test(navigator.userAgent.toLowerCase())) {
-      cordova.InAppBrowser.open(this.preferences.storeAppURL.windows8, '_system', 'location=no');
+      AppRate.preferences.openUrl(this.preferences.storeAppURL.windows8);
     }
     return this;
   };


### PR DESCRIPTION
Until now even if someone used safariviewcontroller instead of inappbrowser, this plugin forced him to also install and use inappbrowser. This fix allows to choose between them to let the people who want to continue use inappbrowser, to continue with it and the ones who want safariviewcontroller to not force them to install inappbrowser.

https://github.com/EddyVerbruggen/cordova-plugin-safariviewcontroller
https://github.com/apache/cordova-plugin-inappbrowser