### PR TITLE
fix(typings): add openUrl to AppRatePreferences

### DIFF
--- a/typescript/AppRate.d.ts
+++ b/typescript/AppRate.d.ts
@@ -37,6 +37,7 @@ declare class AppRatePreferences {
   callbacks:CallbackPreferences;
   storeAppURL:StoreAppURLPreferences;
   customLocale:CustomLocale;
+  openUrl:(url:string) => void;
 }
 
 declare class StoreAppURLPreferences {


### PR DESCRIPTION
openUrl property is missing on the typings file.