### PR TITLE
feat: Android native in app review + revised native reviews flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - UNRELEASED
   - [PR #280](https://github.com/pushandplay/cordova-plugin-apprate/pull/280) - Removed iOS option `inAppReview` in favor of new option `reviewType`. Please update your app according to the updated documentation
   - [PR #280](https://github.com/pushandplay/cordova-plugin-apprate/pull/280) - Fixed race condition on `deviceready` events causing the module to not be fully initialized
+  - [PR #281](https://github.com/pushandplay/cordova-plugin-apprate/pull/281) - feature: Android in-app review
  
 - 1.5.0
   - [PR #253](https://github.com/pushandplay/cordova-plugin-apprate/pull/253) - Remove iOS rating counter in favor of native approach

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ AppRate.preferences.openUrl = function (url) {
 
 ## Integrating Google Play Core
 
-To set up Google Play Core version, you can use PLAY_CORE_VERSION parameter (with 1.8.0 value by default). It is useful in order to avoid conflicts with another plugins which use any other different version of Google Play Core.
+To set up Google Play Core version, you can use PLAY_CORE_VERSION parameter (with `1.+` value by default). It is useful in order to avoid conflicts with another plugins which use any other different version of Google Play Core.
 
 ## Customization and usage
 

--- a/README.md
+++ b/README.md
@@ -60,14 +60,14 @@ AppRate.preferences.openUrl = function (url) {
 - From github repository: `cordova plugin add https://github.com/pushandplay/cordova-plugin-apprate.git`
 - For phonegap build add the following to your config.xml: `<gap:plugin name="cordova-plugin-apprate" />`
 
-## Integrating Google Play Services
+## Integrating Google Play Core
 
 To set up Google Play Core version, you can use PLAY_CORE_VERSION parameter (with 1.8.0 value by default). It is useful in order to avoid conflicts with another plugins which use any other different version of Google Play Core.
 
 ## Customization and usage
 
 - Note: During development the submit button will be disabled and cannot be pressed. This is expected behavior per Apple when the app has not been downloaded from the app store. Details here: https://github.com/pushandplay/cordova-plugin-apprate/issues/182
-- Note: Using the in app review for Android/IOS will not prompt the user, and the native review prompt will be _requested_ and not guaranteed to be shown
+- Note: Using the in-app review for Android/iOS will not prompt the user, and the native review prompt will be _requested_ and not guaranteed to be shown
 
 ## Options / Preferences
 These options are available on the `AppRate.preferences` object. 
@@ -78,8 +78,8 @@ These options are available on the `AppRate.preferences` object.
 | displayAppName | String | '' | custom application title |
 | promptAgainForEachNewVersion | Boolean | true | show dialog again when application version will be updated |
 | usesUntilPrompt | Integer | 3 | count of runs of application before dialog will be displayed |
-| reviewType.ios | [Enum](#reviewtypeios-enum) | AppStoreReview | the type of review display to show the user on ios |
-| reviewType.android | [Enum](#reviewtypeandroid-enum) | InAppBrowser | the type of review display to show the user on android |
+| reviewType.ios | [Enum](#reviewtypeios-enum) | AppStoreReview | the type of review display to show the user on iOS |
+| reviewType.android | [Enum](#reviewtypeandroid-enum) | InAppBrowser | the type of review display to show the user on Android |
 | simpleMode | Boolean | false | enabling simplemode would display the rate dialog directly without the negative feedback filtering flow |
 | callbacks.onButtonClicked | Function | null | call back function. called when user clicked on rate-dialog buttons |
 | callbacks.onRateDialogShow | Function | null | call back function. called when rate-dialog showing |
@@ -91,12 +91,12 @@ These options are available on the `AppRate.preferences` object.
 | customLocale | Object | null | custom locale object |
 
 ### reviewType.ios Enum
-- 'InAppReview' - Write review directly in your application (iOS 10.3+), limited to 3 prompts per year. Fallback to 'AppStoreReview' for other iOS versions. No custom prompt will be shown to the user per apple requirments
+- 'InAppReview' - Write review directly in your application (iOS 10.3+), limited to 3 prompts per year. Fallback to 'AppStoreReview' for other iOS versions. No custom prompt will be shown to the user per Apple's requirments
 - 'AppStoreReview' - Open the store within the app. Use this option as an alternative to inAppReview to avoid the rate action from [doing nothing](https://developer.apple.com/documentation/storekit/skstorereviewcontroller/2851536-requestreview)
 - 'InAppBrowser' - Open the store using the `openUrl` preference (defaults to InAppBrowser). Be advised that WKWebView might not open the app store links
 
 ### reviewType.android Enum
-- 'InAppReview' - Write review directly in your application. No custom prompt will be shown to the user per android requirments. Notice this will only work on released versions. To test it our please refer to [this article](https://developer.android.com/guide/playcore/in-app-review/test)
+- 'InAppReview' - Write review directly in your application. No custom prompt will be shown to the user per Android's requirments. Notice this will only work on released versions. To test it our please refer to [this article](https://developer.android.com/guide/playcore/in-app-review/test)
 - 'InAppBrowser' - Open the store using the `openUrl` preference (defaults to InAppBrowser)
 
 ## Examples

--- a/README.md
+++ b/README.md
@@ -60,9 +60,14 @@ AppRate.preferences.openUrl = function (url) {
 - From github repository: `cordova plugin add https://github.com/pushandplay/cordova-plugin-apprate.git`
 - For phonegap build add the following to your config.xml: `<gap:plugin name="cordova-plugin-apprate" />`
 
+## Integrating Google Play Services
+
+To set up Google Play Core version, you can use PLAY_CORE_VERSION parameter (with 1.8.0 value by default). It is useful in order to avoid conflicts with another plugins which use any other different version of Google Play Core.
+
 ## Customization and usage
 
 - Note: During development the submit button will be disabled and cannot be pressed. This is expected behavior per Apple when the app has not been downloaded from the app store. Details here: https://github.com/pushandplay/cordova-plugin-apprate/issues/182
+- Note: Using the in app review for Android/IOS will not prompt the user, and the native review prompt will be _requested_ and not guaranteed to be shown
 
 ## Options / Preferences
 These options are available on the `AppRate.preferences` object. 
@@ -73,8 +78,9 @@ These options are available on the `AppRate.preferences` object.
 | displayAppName | String | '' | custom application title |
 | promptAgainForEachNewVersion | Boolean | true | show dialog again when application version will be updated |
 | usesUntilPrompt | Integer | 3 | count of runs of application before dialog will be displayed |
-| reviewType.ios | [Enum](#reviewtypeios-enum) | AppStoreReview | the type of review display to show the user |
-| simpleMode | Boolean | false | enabling simplemode would display the rate dialog directly without the negative feedback filtering flow|
+| reviewType.ios | [Enum](#reviewtypeios-enum) | AppStoreReview | the type of review display to show the user on ios |
+| reviewType.android | [Enum](#reviewtypeandroid-enum) | InAppBrowser | the type of review display to show the user on android |
+| simpleMode | Boolean | false | enabling simplemode would display the rate dialog directly without the negative feedback filtering flow |
 | callbacks.onButtonClicked | Function | null | call back function. called when user clicked on rate-dialog buttons |
 | callbacks.onRateDialogShow | Function | null | call back function. called when rate-dialog showing |
 | storeAppURL.ios | String | null | application id in AppStore |
@@ -85,9 +91,13 @@ These options are available on the `AppRate.preferences` object.
 | customLocale | Object | null | custom locale object |
 
 ### reviewType.ios Enum
+- 'InAppReview' - Write review directly in your application (iOS 10.3+), limited to 3 prompts per year. Fallback to 'AppStoreReview' for other iOS versions. No custom prompt will be shown to the user per apple requirments
 - 'AppStoreReview' - Open the store within the app. Use this option as an alternative to inAppReview to avoid the rate action from [doing nothing](https://developer.apple.com/documentation/storekit/skstorereviewcontroller/2851536-requestreview)
-- 'InAppReview' - Write review directly in your application (iOS 10.3+), limit of 3 prompts per year. Fallback to 'AppStoreReview' for other iOS versions
 - 'InAppBrowser' - Open the store using the `openUrl` preference (defaults to InAppBrowser). Be advised that WKWebView might not open the app store links
+
+### reviewType.android Enum
+- 'InAppReview' - Write review directly in your application. No custom prompt will be shown to the user per android requirments. Notice this will only work on released versions. To test it our please refer to [this article](https://developer.android.com/guide/playcore/in-app-review/test)
+- 'InAppBrowser' - Open the store using the `openUrl` preference (defaults to InAppBrowser)
 
 ## Examples
 
@@ -154,7 +164,8 @@ AppRate.preferences = {
   usesUntilPrompt: 5,
   promptAgainForEachNewVersion: false,
   reviewType: {
-    ios: 'InAppReview'
+    ios: 'InAppReview',
+    android: 'InAppReview'
   },
   storeAppURL: {
     ios: '<my_app_id>',
@@ -231,7 +242,8 @@ AppRate.preferences = {
   usesUntilPrompt: 5,
   promptAgainForEachNewVersion: false,
   reviewType: {
-    ios: 'InAppReview'
+    ios: 'InAppReview',
+    android: 'InAppReview'
   },
   storeAppURL: {
     ios: '<my_app_id>',

--- a/README.md
+++ b/README.md
@@ -164,8 +164,8 @@ AppRate.preferences = {
   usesUntilPrompt: 5,
   promptAgainForEachNewVersion: false,
   reviewType: {
-    ios: 'InAppReview',
-    android: 'InAppReview'
+    ios: 'AppStoreReview',
+    android: 'InAppBrowser'
   },
   storeAppURL: {
     ios: '<my_app_id>',
@@ -242,8 +242,8 @@ AppRate.preferences = {
   usesUntilPrompt: 5,
   promptAgainForEachNewVersion: false,
   reviewType: {
-    ios: 'InAppReview',
-    android: 'InAppReview'
+    ios: 'AppStoreReview',
+    android: 'InAppBrowser'
   },
   storeAppURL: {
     ios: '<my_app_id>',

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ AppRate.preferences.openUrl = function (url) {
           SafariViewController.show({
                 url: url,
                 barColor: "#0000ff", // on iOS 10+ you can change the background color as well
-                controlTintColor: "#00ffff" // on iOS 10+ you can override the default tintColor
+                controlTintColor: "#00ffff", // on iOS 10+ you can override the default tintColor
                 tintColor: "#00ffff", // should be set to same value as controlTintColor and will be a fallback on older ios
               },
               // this success handler will be invoked for the lifecycle events 'opened', 'loaded' and 'closed'

--- a/README.md
+++ b/README.md
@@ -90,14 +90,28 @@ These options are available on the `AppRate.preferences` object.
 | storeAppURL.windows8 | String | null | application URL in WindowsStore |
 | customLocale | Object | null | custom locale object |
 
-### reviewType.ios Enum
-- 'InAppReview' - Write review directly in your application (iOS 10.3+), limited to 3 prompts per year. Fallback to 'AppStoreReview' for other iOS versions. No custom prompt will be shown to the user per Apple's requirments
-- 'AppStoreReview' - Open the store within the app. Use this option as an alternative to inAppReview to avoid the rate action from [doing nothing](https://developer.apple.com/documentation/storekit/skstorereviewcontroller/2851536-requestreview)
-- 'InAppBrowser' - Open the store using the `openUrl` preference (defaults to InAppBrowser). Be advised that WKWebView might not open the app store links
+### reviewType
 
-### reviewType.android Enum
-- 'InAppReview' - Write review directly in your application. No custom prompt will be shown to the user per Android's requirments. Notice this will only work on released versions. To test it our please refer to [this article](https://developer.android.com/guide/playcore/in-app-review/test)
-- 'InAppBrowser' - Open the store using the `openUrl` preference (defaults to InAppBrowser)
+The `InAppReview` review type will attempt to launch a native in-app review dialog (as opposed to opening the app store).
+   
+The native dialog is designed to maintain the privacy of the users and to prevent applications from harassing them with too many review requests. 
+As such, the dialog might or might not appear, and we will not be able to know whether it appeared, or whether the user reviewed the app or not.  
+
+Since we can't know if the dialog will be shown, and in order to comply to the requirements of Apple/Android, 
+no custom prompt will be shown to the user before attempting to open the in-app review dialog.
+
+Native in-app review can only be possible under certain conditions. If those conditions are not met, a fallback method will be used (see information per platform below).
+
+#### reviewType.ios [Enum]
+- `InAppReview` - Write review directly in your application (iOS 10.3+), limited to 3 prompts per year. Will fallback to 'AppStoreReview' for other iOS versions
+- `AppStoreReview` - Open the store within the app. Use this option as an alternative to inAppReview to avoid the rate action from [doing nothing](https://developer.apple.com/documentation/storekit/skstorereviewcontroller/2851536-requestreview)
+- `InAppBrowser` - Open the store using the `openUrl` preference (defaults to InAppBrowser). Be advised that WKWebView might not open the app store links
+
+#### reviewType.android [Enum]
+- `InAppReview` - Write review directly in your application. Will fallback to `InAppBrowser` if not available
+- `InAppBrowser` - Open the store using the `openUrl` preference (defaults to InAppBrowser)
+
+Notice that the `InAppReview` will only work on released versions. To test it our please refer to [this article](https://developer.android.com/guide/playcore/in-app-review/test)
 
 ## Examples
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -49,6 +49,8 @@ under the License.
     </js-module>
 
     <platform name="android">
+        <preference name="PLAY_CORE_VERSION" default="1.8.0"/>
+        <framework src="com.google.android.play:core:$PLAY_CORE_VERSION" />
         <source-file src="src/android/AppRate.java" target-dir="src/org/pushandplay/cordova/apprate"/>
 
         <config-file target="res/xml/config.xml" parent="/*">

--- a/plugin.xml
+++ b/plugin.xml
@@ -49,7 +49,7 @@ under the License.
     </js-module>
 
     <platform name="android">
-        <preference name="PLAY_CORE_VERSION" default="1.8.0"/>
+        <preference name="PLAY_CORE_VERSION" default="1.+"/>
         <framework src="com.google.android.play:core:$PLAY_CORE_VERSION" />
         <source-file src="src/android/AppRate.java" target-dir="src/org/pushandplay/cordova/apprate"/>
 

--- a/src/android/AppRate.java
+++ b/src/android/AppRate.java
@@ -2,37 +2,73 @@ package org.pushandplay.cordova.apprate;
 
 import org.apache.cordova.CordovaPlugin;
 import org.apache.cordova.CallbackContext;
+import org.apache.cordova.LOG;
+import org.apache.cordova.PluginResult;
 import org.json.JSONArray;
 import org.json.JSONException;
-import org.json.JSONObject;
 
+import android.app.Activity;
 import android.content.pm.PackageManager.NameNotFoundException;
 import android.content.pm.PackageManager;
 import android.content.pm.ApplicationInfo;
 
+import com.google.android.play.core.review.ReviewInfo;
+import com.google.android.play.core.review.ReviewManager;
+import com.google.android.play.core.review.ReviewManagerFactory;
+import com.google.android.play.core.tasks.Task;
+
 public class AppRate extends CordovaPlugin {
-	@Override
-	public boolean execute(String action, JSONArray args, final CallbackContext callbackContext) throws JSONException
-	{
-		try {
-			PackageManager packageManager = this.cordova.getActivity().getPackageManager();
-
-			if (action.equals("getAppVersion")){
-				callbackContext.success(packageManager.getPackageInfo(this.cordova.getActivity().getPackageName(), 0).versionName);
-				return true;
-			}
-			if (action.equals("getAppTitle")) {
-				ApplicationInfo applicationInfo = packageManager.getApplicationInfo(this.cordova.getActivity().getApplicationContext().getApplicationInfo().packageName, 0);
-				final String applicationName = (String) (applicationInfo != null ? packageManager.getApplicationLabel(applicationInfo) : "Unknown");
-
-                callbackContext.success(applicationName);
-
-                return true;
-			}
-			return false;
-		} catch (NameNotFoundException e) {
-			callbackContext.success("N/A");
-			return true;
-		}
-	}
+  @Override
+  public boolean execute(String action, JSONArray args, final CallbackContext callbackContext) throws JSONException {
+    try {
+      if (action.equals("isNativePromptAvailable")) {
+        PluginResult pluginResult = new PluginResult(PluginResult.Status.OK, true);
+        callbackContext.sendPluginResult(pluginResult);
+        return true;
+      }
+      if (action.equals("getAppVersion")) {
+        PackageManager packageManager = this.cordova.getActivity().getPackageManager();
+        callbackContext.success(packageManager.getPackageInfo(this.cordova.getActivity().getPackageName(), 0).versionName);
+        return true;
+      }
+      if (action.equals("getAppTitle")) {
+        PackageManager packageManager = this.cordova.getActivity().getPackageManager();
+        ApplicationInfo applicationInfo = packageManager.getApplicationInfo(this.cordova.getActivity().getApplicationContext().getApplicationInfo().packageName, 0);
+        final String applicationName = (String) (applicationInfo != null ? packageManager.getApplicationLabel(applicationInfo) : "Unknown");
+        callbackContext.success(applicationName);
+        return true;
+      }
+      if (action.equals("launchReview")) {
+        Activity activity = this.cordova.getActivity();
+        ReviewManager manager = ReviewManagerFactory.create(activity);
+        Task<ReviewInfo> request = manager.requestReviewFlow();
+        request.addOnCompleteListener(task -> {
+          if (task.isSuccessful()) {
+            LOG.d("AppRate", "request review success");
+            ReviewInfo reviewInfo = task.getResult();
+            Task<Void> flow = manager.launchReviewFlow(activity, reviewInfo);
+            flow.addOnCompleteListener(launchTask -> {
+              if (task.isSuccessful()) {
+                LOG.d("AppRate", "launch review success");
+                callbackContext.success();
+              } else {
+                Exception error = task.getException();
+                LOG.d("AppRate", "Failed to launch review", error);
+                callbackContext.error("Failed to launch review - " + error.getMessage());
+              }
+            });
+          } else {
+            Exception error = task.getException();
+            LOG.d("AppRate", "Failed to launch review", error);
+            callbackContext.error("Failed to launch review flow - " + error.getMessage());
+          }
+        });
+        return true;
+      }
+      return false;
+    } catch (NameNotFoundException e) {
+      callbackContext.success("N/A");
+      return true;
+    }
+  }
 }

--- a/src/ios/CDVAppRate.h
+++ b/src/ios/CDVAppRate.h
@@ -26,6 +26,8 @@
 
 - (void)getAppTitle:(CDVInvokedUrlCommand *)command;
 
+- (void)isNativePromptAvailable:(CDVInvokedUrlCommand *)command;
+
 - (void)launchiOSReview:(CDVInvokedUrlCommand *)command;
 
 - (void)launchAppStore:(NSString *)appId;

--- a/src/ios/CDVAppRate.m
+++ b/src/ios/CDVAppRate.m
@@ -41,6 +41,12 @@
     }];
 }
 
+- (void)isNativePromptAvailable:(CDVInvokedUrlCommand *)command {
+    BOOL isNativePromptAvailable = [SKStoreReviewController class];
+    CDVPluginResult * pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsBool:isNativePromptAvailable];
+    [self.commandDelegate sendPluginResult : pluginResult callbackId : command.callbackId];
+}
+
 - (void)launchiOSReview:(CDVInvokedUrlCommand *)command {
     BOOL shouldUseNativePrompt = [command.arguments[1] boolValue];
 

--- a/typescript/AppRate.d.ts
+++ b/typescript/AppRate.d.ts
@@ -37,6 +37,7 @@ declare module "cordova-plugin-apprate" {
     usesUntilPrompt: number;
     reviewType: {
       ios: 'AppStoreReview' | 'InAppReview' | 'InAppBrowser';
+      android: 'InAppReview' | 'InAppBrowser';
     };
     simpleMode: boolean;
     callbacks: CallbackPreferences;

--- a/www/AppRate.js
+++ b/www/AppRate.js
@@ -141,6 +141,7 @@ var AppRate = (function() {
       if (AppRate.preferences.isNativePromptAvailable && AppRate.preferences.reviewType) {
         if ((IS_IOS && AppRate.preferences.reviewType.ios === 'InAppReview')
         || (IS_ANDROID && AppRate.preferences.reviewType.android === 'InAppReview')) {
+          updateCounter('stop');
           AppRate.navigateToAppStore();
         }
       } else if(AppRate.preferences.simpleMode) {

--- a/www/AppRate.js
+++ b/www/AppRate.js
@@ -301,7 +301,7 @@ var AppRate = (function() {
         AppRate.preferences.openUrl(iOSStoreUrl);
       }
     } else if (IS_ANDROID) {
-      if (this.preferences.reviewType && this.preferences.reviewType.android === 'InAppReview') {
+      if (AppRate.preferences.isNativePromptAvailable && this.preferences.reviewType && this.preferences.reviewType.android === 'InAppReview') {
         exec(null, null, 'AppRate', 'launchReview', []);
       } else {
         AppRate.preferences.openUrl(this.preferences.storeAppURL.android);

--- a/www/AppRate.js
+++ b/www/AppRate.js
@@ -18,38 +18,40 @@
   * under the License.
   *
   */;
-var AppRate, Locales, localeObj, exec, Storage;
+var exec = require('cordova/exec');
+var Locales = require('./locales');
+var Storage = require('./storage')
 
-Locales = require('./locales');
+var AppRate = (function() {
 
-exec = require('cordova/exec');
+  function noop(){}
 
-Storage = require('./storage')
-
-AppRate = (function() {
-  var FLAG_NATIVE_CODE_SUPPORTED, LOCAL_STORAGE_COUNTER, counter, getAppTitle, getAppVersion, showDialog, updateCounter;
+  var localeObj;
 
   function AppRate() {}
+
   AppRate.initialized = false;
   AppRate.ready = new Promise(function (resolve, reject) {
     AppRate.readyResolve = resolve;
     AppRate.readyReject = reject;
   });
 
-  LOCAL_STORAGE_COUNTER = 'counter';
+  var LOCAL_STORAGE_COUNTER = 'counter';
 
-  FLAG_NATIVE_CODE_SUPPORTED = /(iPhone|iPod|iPad|Android)/i.test(navigator.userAgent.toLowerCase());
+  var FLAG_IOS_NATIVE_CODE_SUPPORTED = /(iPhone|iPod|iPad)/i.test(navigator.userAgent.toLowerCase());
+  var FLAG_ANDROID_NATIVE_CODE_SUPPORTED = /Android/i.test(navigator.userAgent.toLowerCase());
+  var FLAG_NATIVE_CODE_SUPPORTED = FLAG_IOS_NATIVE_CODE_SUPPORTED || FLAG_ANDROID_NATIVE_CODE_SUPPORTED;
 
-  PREF_STORE_URL_PREFIX_IOS9 = "itms-apps://itunes.apple.com/app/viewContentsUserReviews/id";
-  PREF_STORE_URL_POSTFIX_IOS9 = "?action=write-review";
-  PREF_STORE_URL_FORMAT_IOS8 = "http://itunes.apple.com/WebObjects/MZStore.woa/wa/viewContentsUserReviews?pageNumber=0&sortOrdering=1&type=Purple+Software&mt=8&id=";
+  var PREF_STORE_URL_PREFIX_IOS9 = "itms-apps://itunes.apple.com/app/viewContentsUserReviews/id";
+  var PREF_STORE_URL_POSTFIX_IOS9 = "?action=write-review";
+  var PREF_STORE_URL_FORMAT_IOS8 = "http://itunes.apple.com/WebObjects/MZStore.woa/wa/viewContentsUserReviews?pageNumber=0&sortOrdering=1&type=Purple+Software&mt=8&id=";
 
-  counter = {
+  var counter = {
     applicationVersion: void 0,
     countdown: 0
   };
 
-  promptForAppRatingWindowButtonClickHandler = function (buttonIndex) {
+  function promptForAppRatingWindowButtonClickHandler(buttonIndex) {
     var base = AppRate.preferences.callbacks, currentBtn = null;
     switch (buttonIndex) {
       case 0:
@@ -67,9 +69,9 @@ AppRate = (function() {
         break;
     }
     return typeof base.onButtonClicked === "function" ? base.onButtonClicked(buttonIndex, currentBtn, "AppRatingPrompt") : function(){ };
-  };
+  }
 
-  promptForStoreRatingWindowButtonClickHandler = function(buttonIndex) {
+  function promptForStoreRatingWindowButtonClickHandler(buttonIndex) {
     var base = AppRate.preferences.callbacks, currentBtn = null;
     switch (buttonIndex) {
       case 0:
@@ -93,9 +95,9 @@ AppRate = (function() {
     typeof base.onButtonClicked === "function" ? base.onButtonClicked(buttonIndex, currentBtn, "StoreRatingPrompt") : function(){ };
     //This one is called anyway once the process is done
     return typeof base.done === "function" ? base.done() : function(){ };
-  };
+  }
 
-  promptForFeedbackWindowButtonClickHandler = function(buttonIndex) {
+  function promptForFeedbackWindowButtonClickHandler(buttonIndex) {
     var base = AppRate.preferences.callbacks, currentBtn = null;
     switch (buttonIndex) {
       case 1:
@@ -109,9 +111,9 @@ AppRate = (function() {
         break;
     }
     return typeof base.onButtonClicked === "function" ? base.onButtonClicked(buttonIndex, currentBtn, "FeedbackPrompt") : function(){ };
-  };
+  }
 
-  updateCounter = function(action) {
+  function updateCounter(action) {
     if (action == null) {
       action = 'increment';
     }
@@ -129,14 +131,19 @@ AppRate = (function() {
     }
     Storage.set(LOCAL_STORAGE_COUNTER, counter);
     return counter;
-  };
+  }
 
-  showDialog = function(immediately) {
+  function showDialog(immediately) {
     updateCounter();
     if (counter.countdown === AppRate.preferences.usesUntilPrompt || immediately) {
       localeObj = Locales.getLocale(AppRate.preferences.useLanguage, AppRate.preferences.displayAppName, AppRate.preferences.customLocale);
 
-      if(AppRate.preferences.simpleMode) {
+      if (AppRate.preferences.isNativePromptAvailable && AppRate.preferences.reviewType) {
+        if ((FLAG_IOS_NATIVE_CODE_SUPPORTED && AppRate.preferences.reviewType.ios === 'InAppReview')
+        || (FLAG_ANDROID_NATIVE_CODE_SUPPORTED && AppRate.preferences.reviewType.android === 'InAppReview')) {
+          AppRate.navigateToAppStore();
+        }
+      } else if(AppRate.preferences.simpleMode) {
         navigator.notification.confirm(localeObj.message, promptForStoreRatingWindowButtonClickHandler, localeObj.title, [localeObj.cancelButtonLabel, localeObj.laterButtonLabel, localeObj.rateButtonLabel]);
       } else {
         navigator.notification.confirm(localeObj.appRatePromptMessage, promptForAppRatingWindowButtonClickHandler, localeObj.appRatePromptTitle, [localeObj.noButtonLabel, localeObj.yesButtonLabel]);
@@ -148,31 +155,72 @@ AppRate = (function() {
       }
     }
     return AppRate;
-  };
+  }
 
-  getAppVersion = function(successCallback, errorCallback) {
-    if (FLAG_NATIVE_CODE_SUPPORTED) {
-      exec(successCallback, errorCallback, 'AppRate', 'getAppVersion', []);
-    } else {
-      successCallback(counter.applicationVersion);
-    }
-    return AppRate;
-  };
+  function getAppVersion() {
+    return new Promise(function (resolve, reject){
+      if (FLAG_NATIVE_CODE_SUPPORTED) {
+        exec(resolve, reject, 'AppRate', 'getAppVersion', []);
+      } else {
+        resolve(counter.applicationVersion);
+      }
+    });
+  }
 
-  getAppTitle = function(successCallback, errorCallback) {
-    if (FLAG_NATIVE_CODE_SUPPORTED) {
-      exec(successCallback, errorCallback, 'AppRate', 'getAppTitle', []);
-    } else {
-      successCallback(AppRate.preferences.displayAppName);
-    }
-    return AppRate;
-  };
+  function getAppTitle() {
+    return new Promise(function (resolve, reject){
+      if (FLAG_NATIVE_CODE_SUPPORTED) {
+        exec(resolve, reject, 'AppRate', 'getAppTitle', []);
+      } else {
+        resolve(AppRate.preferences.displayAppName);
+      }
+    });
+  }
+
+  function isNativePromptAvailable() {
+    return new Promise(function (resolve, reject){
+      if (FLAG_NATIVE_CODE_SUPPORTED) {
+        exec(resolve, reject, 'AppRate', 'isNativePromptAvailable', []);
+      } else {
+        resolve(false);
+      }
+    });
+  }
 
   AppRate.init = function() {
-    var initPromise = Promise.all([
-      Storage.get(LOCAL_STORAGE_COUNTER).then(function (storedCounter) {
-        counter = storedCounter || counter
+    var appVersionPromise = getAppVersion()
+      .then(function(applicationVersion) {
+        if (counter.applicationVersion !== applicationVersion) {
+          counter.applicationVersion = applicationVersion;
+          if (AppRate.preferences.promptAgainForEachNewVersion) {
+            updateCounter('reset');
+          }
+        }
       })
+      .catch(noop);
+
+    var appTitlePromise = getAppTitle()
+      .then(function(displayAppName) {
+        AppRate.preferences.displayAppName = displayAppName;
+      })
+      .catch(noop);
+
+    var isNativePromptAvailablePromise = isNativePromptAvailable()
+      .then(function(isNativePromptAvailable) {
+        AppRate.preferences.isNativePromptAvailable = isNativePromptAvailable;
+      })
+      .catch(function () {
+        AppRate.preferences.isNativePromptAvailable = false;
+      });
+
+    var storagePromise = Storage.get(LOCAL_STORAGE_COUNTER).then(function (storedCounter) {
+      counter = storedCounter || counter
+    });
+    var initPromise = Promise.all([
+      isNativePromptAvailablePromise,
+      appVersionPromise,
+      appTitlePromise,
+      storagePromise
     ]);
     if (AppRate.initialized) {
       AppRate.ready = initPromise;
@@ -182,24 +230,6 @@ AppRate = (function() {
         .then(AppRate.readyResolve)
         .catch(AppRate.readyReject);
     }
-
-    getAppVersion((function(_this) {
-      return function(applicationVersion) {
-        if (counter.applicationVersion !== applicationVersion) {
-          counter.applicationVersion = applicationVersion;
-          if (_this.preferences.promptAgainForEachNewVersion) {
-            updateCounter('reset');
-          }
-        }
-        return _this;
-      };
-    })(this));
-    getAppTitle((function(_this) {
-      return function(displayAppName) {
-        _this.preferences.displayAppName = displayAppName;
-        return _this;
-      };
-    })(this));
     return this;
   };
 
@@ -211,8 +241,10 @@ AppRate = (function() {
     simpleMode: false,
     promptAgainForEachNewVersion: true,
     usesUntilPrompt: 3,
+    isNativePromptAvailable: false,
     reviewType: {
-      ios: 'AppStoreReview'
+      ios: 'AppStoreReview',
+      android: 'InAppBrowser'
     },
     callbacks: {
       onButtonClicked: null,
@@ -253,7 +285,7 @@ AppRate = (function() {
     var iOSVersion;
     var iOSStoreUrl;
 
-    if (/(iPhone|iPod|iPad)/i.test(navigator.userAgent.toLowerCase())) {
+    if (FLAG_IOS_NATIVE_CODE_SUPPORTED) {
       if (!this.preferences.reviewType || !this.preferences.reviewType.ios || this.preferences.reviewType.ios === 'AppStoreReview') {
         exec(null, null, 'AppRate', 'launchiOSReview', [this.preferences.storeAppURL.ios, false]);
       } else if (this.preferences.reviewType.ios === 'InAppReview') {
@@ -268,8 +300,12 @@ AppRate = (function() {
         }
         AppRate.preferences.openUrl(iOSStoreUrl);
       }
-    } else if (/(Android)/i.test(navigator.userAgent.toLowerCase())) {
-      AppRate.preferences.openUrl(this.preferences.storeAppURL.android);
+    } else if (FLAG_ANDROID_NATIVE_CODE_SUPPORTED) {
+      if (this.preferences.reviewType && this.preferences.reviewType.android === 'InAppReview') {
+        exec(null, null, 'AppRate', 'launchReview', []);
+      } else {
+        AppRate.preferences.openUrl(this.preferences.storeAppURL.android);
+      }
     } else if (/(Windows|Edge)/i.test(navigator.userAgent.toLowerCase())) {
       Windows.Services.Store.StoreRequestHelper.sendRequestAsync(Windows.Services.Store.StoreContext.getDefault(), 16, "");
     } else if (/(BlackBerry)/i.test(navigator.userAgent.toLowerCase())) {

--- a/www/AppRate.js
+++ b/www/AppRate.js
@@ -38,9 +38,9 @@ var AppRate = (function() {
 
   var LOCAL_STORAGE_COUNTER = 'counter';
 
-  var FLAG_IOS_NATIVE_CODE_SUPPORTED = /(iPhone|iPod|iPad)/i.test(navigator.userAgent.toLowerCase());
-  var FLAG_ANDROID_NATIVE_CODE_SUPPORTED = /Android/i.test(navigator.userAgent.toLowerCase());
-  var FLAG_NATIVE_CODE_SUPPORTED = FLAG_IOS_NATIVE_CODE_SUPPORTED || FLAG_ANDROID_NATIVE_CODE_SUPPORTED;
+  var IS_IOS = /(iPhone|iPod|iPad)/i.test(navigator.userAgent.toLowerCase());
+  var IS_ANDROID = /Android/i.test(navigator.userAgent.toLowerCase());
+  var FLAG_NATIVE_CODE_SUPPORTED = IS_IOS || IS_ANDROID;
 
   var PREF_STORE_URL_PREFIX_IOS9 = "itms-apps://itunes.apple.com/app/viewContentsUserReviews/id";
   var PREF_STORE_URL_POSTFIX_IOS9 = "?action=write-review";
@@ -139,8 +139,8 @@ var AppRate = (function() {
       localeObj = Locales.getLocale(AppRate.preferences.useLanguage, AppRate.preferences.displayAppName, AppRate.preferences.customLocale);
 
       if (AppRate.preferences.isNativePromptAvailable && AppRate.preferences.reviewType) {
-        if ((FLAG_IOS_NATIVE_CODE_SUPPORTED && AppRate.preferences.reviewType.ios === 'InAppReview')
-        || (FLAG_ANDROID_NATIVE_CODE_SUPPORTED && AppRate.preferences.reviewType.android === 'InAppReview')) {
+        if ((IS_IOS && AppRate.preferences.reviewType.ios === 'InAppReview')
+        || (IS_ANDROID && AppRate.preferences.reviewType.android === 'InAppReview')) {
           AppRate.navigateToAppStore();
         }
       } else if(AppRate.preferences.simpleMode) {
@@ -285,7 +285,7 @@ var AppRate = (function() {
     var iOSVersion;
     var iOSStoreUrl;
 
-    if (FLAG_IOS_NATIVE_CODE_SUPPORTED) {
+    if (IS_IOS) {
       if (!this.preferences.reviewType || !this.preferences.reviewType.ios || this.preferences.reviewType.ios === 'AppStoreReview') {
         exec(null, null, 'AppRate', 'launchiOSReview', [this.preferences.storeAppURL.ios, false]);
       } else if (this.preferences.reviewType.ios === 'InAppReview') {
@@ -300,7 +300,7 @@ var AppRate = (function() {
         }
         AppRate.preferences.openUrl(iOSStoreUrl);
       }
-    } else if (FLAG_ANDROID_NATIVE_CODE_SUPPORTED) {
+    } else if (IS_ANDROID) {
       if (this.preferences.reviewType && this.preferences.reviewType.android === 'InAppReview') {
         exec(null, null, 'AppRate', 'launchReview', []);
       } else {


### PR DESCRIPTION
fix: #276 

This PR adds the native Android in-app review feature.

Since both Apple and Android in-app reviews explicitly dictate not to prompt the user before calling the review API (as it might not be shown at all) I have revised the logic so if someone wants in-app review (in Android and/or IOS) and the native prompt is supported,  no custom prompt will be shown (breaking change)

Backward compatibility was also in mind. Also, it will be bulletproof to CodePush updates that will update the js file of the plugin without updating the native code.
@westonganger I would appreciate your review and thoughts.

Please note that the Android in-app review is very hard to debug/display as I mentioned in the readme and can only be done in test track releases. ~~I managed to get the native prompt logic to work on the test track version of my app with this PR but Android refuses to actually show me the dialog (all the callbacks states success results). Since this is a really new feature, there is not much info on the web to help debug it. So I would appreciate if someone can test it out and see if it works for them @terreng @rodrigograca31~~
I confirmed the PR works perfectly in Android

![WhatsApp Image 2020-09-05 at 21 45 44](https://user-images.githubusercontent.com/5775519/92311613-34b19000-efc1-11ea-95ae-07fae31aae46.jpeg)
