### PR TITLE
fix: Improvement of AppRate.init

### DIFF
--- a/www/AppRate.js
+++ b/www/AppRate.js
@@ -236,17 +236,6 @@ var AppRate = (function() {
   }
 
   AppRate.init = function() {
-    var appVersionPromise = getAppVersion()
-      .then(function(applicationVersion) {
-        if (counter.applicationVersion !== applicationVersion) {
-          counter.applicationVersion = applicationVersion;
-          if (preferences.promptAgainForEachNewVersion) {
-            updateCounter('reset');
-          }
-        }
-      })
-      .catch(noop);
-
     var appTitlePromise = getAppTitle()
       .then(function(displayAppName) {
         preferences.displayAppName = displayAppName;
@@ -261,12 +250,22 @@ var AppRate = (function() {
         isNativePromptAvailable = false;
       });
 
-    var storagePromise = Storage.get(LOCAL_STORAGE_COUNTER).then(function(storedCounter) {
-      counter = storedCounter || counter
-    });
+    var storagePromise = Storage.get(LOCAL_STORAGE_COUNTER)
+      .then(function(storedCounter) {
+        counter = storedCounter || counter;
+        return getAppVersion();
+      })
+      .then(function(applicationVersion) {
+        if (counter.applicationVersion !== applicationVersion) {
+          counter.applicationVersion = applicationVersion;
+          if (preferences.promptAgainForEachNewVersion) {
+            updateCounter('reset');
+          }
+        }
+      })
+      .catch(noop);
     var initPromise = Promise.all([
       checkIsNativePromptAvailablePromise,
-      appVersionPromise,
       appTitlePromise,
       storagePromise
     ]);


### PR DESCRIPTION
I have come up with some suggestions for improvements to the following issues.

[#270](https://github.com/pushandplay/cordova-plugin-apprate/issues/270)

When initializing, if (counter.applicationVersion ! == applicationVersion) in line 241 could be executed with no localstorage counter being obtained.
This is because appVersionPromise and storagePromise are processed in parallel using Promise.all.

In the above case, since counter.applicationVersion is undefined, if the argument of AppRate.promptForRating is set to false, the updateCounter('reset'); on line 244 will always be executed and the dialog will not be displayed.

I would suggest that you connect getAppVersion() to Storage.get() synchronously.

@westonganger can you please review?