### PR TITLE
fix customLocale initial value

### DIFF
--- a/www/AppRate.js
+++ b/www/AppRate.js
@@ -77,7 +77,19 @@ var AppRate = (function() {
       windows8: null,
       windows: null
     },
-    customLocale: null,
+    customLocale: {
+      title: null,
+      message: null,
+      cancelButtonLabel: null,
+      laterButtonLabel: null,
+      rateButtonLabel: null,
+      yesButtonLabel: null,
+      noButtonLabel: null,
+      appRatePromptTitle: null,
+      feedbackPromptTitle: null,
+      appRatePromptMessage: null,
+      feedbackPromptMessage: null,
+    },
     openUrl: function(url) {
       cordova.InAppBrowser.open(url, '_system', 'location=no');
     }

--- a/www/AppRate.js
+++ b/www/AppRate.js
@@ -77,19 +77,7 @@ var AppRate = (function() {
       windows8: null,
       windows: null
     },
-    customLocale: {
-      title: null,
-      message: null,
-      cancelButtonLabel: null,
-      laterButtonLabel: null,
-      rateButtonLabel: null,
-      yesButtonLabel: null,
-      noButtonLabel: null,
-      appRatePromptTitle: null,
-      feedbackPromptTitle: null,
-      appRatePromptMessage: null,
-      feedbackPromptMessage: null,
-    },
+    customLocale: null,
     openUrl: function(url) {
       cordova.InAppBrowser.open(url, '_system', 'location=no');
     }
@@ -237,7 +225,7 @@ var AppRate = (function() {
     if (pref && typeof pref === 'object') {
       for (let key in pref) {
         if (pref.hasOwnProperty(key) && prefObj.hasOwnProperty(key)) {
-          if (typeof pref[key] === 'object') {
+          if (typeof pref[key] === 'object' && key !== 'customLocale') {
             setPreferences(pref[key], prefObj[key]);
           } else {
             prefObj[key] = pref[key];


### PR DESCRIPTION
I think it would be better to modify the initial value of preferences.customLocale in AppRate.js to match the formatting with Index.d.ts.

At this time, setting customLocale in AppRate.setPreferences will likely result in customLocale = null.

@westonganger can you please review?