### PR TITLE
Fix setPreferences for customLocale

### DIFF
--- a/www/AppRate.js
+++ b/www/AppRate.js
@@ -77,7 +77,19 @@ var AppRate = (function() {
       windows8: null,
       windows: null
     },
-    customLocale: null,
+    customLocale: {
+     appRatePromptMessage: null,
+     appRatePromptTitle: null,
+     cancelButtonLabel: null,
+     feedbackPromptMessage: null,
+     feedbackPromptTitle: null,
+     laterButtonLabel: null,
+     message: null,
+     noButtonLabel: null,
+     rateButtonLabel: null,
+     title: null,
+     yesButtonLabel: null
+    },
     openUrl: function(url) {
       cordova.InAppBrowser.open(url, '_system', 'location=no');
     }

--- a/www/AppRate.js
+++ b/www/AppRate.js
@@ -78,17 +78,17 @@ var AppRate = (function() {
       windows: null
     },
     customLocale: {
-     appRatePromptMessage: null,
-     appRatePromptTitle: null,
-     cancelButtonLabel: null,
-     feedbackPromptMessage: null,
-     feedbackPromptTitle: null,
-     laterButtonLabel: null,
-     message: null,
-     noButtonLabel: null,
-     rateButtonLabel: null,
-     title: null,
-     yesButtonLabel: null
+      appRatePromptMessage: null,
+      appRatePromptTitle: null,
+      cancelButtonLabel: null,
+      feedbackPromptMessage: null,
+      feedbackPromptTitle: null,
+      laterButtonLabel: null,
+      message: null,
+      noButtonLabel: null,
+      rateButtonLabel: null,
+      title: null,
+      yesButtonLabel: null
     },
     openUrl: function(url) {
       cordova.InAppBrowser.open(url, '_system', 'location=no');


### PR DESCRIPTION
Fixes #290 and #292 for me.
The issue here is, that the recursive `setPreferences` method relies on the structure of the second `prefObj` parameter which is null for `customLocale`. This means that `prefObj` is overridden by the default preferences which have nothing in common with the `customLocale`.

I honestly don't know what now happens if no `customLocale` is provided. This should be tested and maybe requires a further fix here.