### PR TITLE
fix(typings): add missing callback arguments for onButtonClicked

### DIFF
--- a/typings/declarations/interfaces/index.d.ts
+++ b/typings/declarations/interfaces/index.d.ts
@@ -1,8 +1,8 @@
 declare module 'cordova-plugin-apprate' {
-
   type ReviewTypeAppStore = 'AppStoreReview';
   type ReviewTypeInApp = 'InAppReview';
   type ReviewTypeBrowser = 'InAppBrowser';
+  type PromptType = 'AppRatingPrompt' | 'StoreRatingPrompt' | 'FeedbackPrompt';
 
   interface AppRatePreferences {
     useLanguage?: string;
@@ -30,7 +30,7 @@ declare module 'cordova-plugin-apprate' {
   }
 
   interface CallbackPreferences {
-    onButtonClicked?: (buttonIndex: number) => void;
+    onButtonClicked?: (buttonIndex: number, buttonLabel: string, promptType: PromptType) => void;
     onRateDialogShow?: (rateCallback: (buttonIndex: number) => void) => void;
     handleNegativeFeedback?: () => void;
     done?: () => void;
@@ -59,7 +59,6 @@ declare module 'cordova-plugin-apprate' {
   }
 
   interface LocaleOptions extends CustomLocale {
-    language: string
+    language: string;
   }
-
 }


### PR DESCRIPTION
Hey hey!

We just noticed that some arguments on the `onButtonClicked` [callback](https://github.com/pushandplay/cordova-plugin-apprate/blob/master/www/AppRate.js#L103) are missing in the type definition. I tried to follow your naming pattern. Let me know if something should be changed!

Happy to get feedback! 😉 