### PR TITLE
chore: Migration from the Play Core Java

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,6 @@
 # Changelog
 
 - Unreleased
-  - Nothing yet
-
-- v1.7.4
   - [PR #334](https://github.com/pushandplay/cordova-plugin-apprate/pull/334) - Migration from the Play Core Java
 
 - v1.7.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 - Unreleased
   - Nothing yet
 
+- v1.7.4
+  - [PR #334](https://github.com/pushandplay/cordova-plugin-apprate/pull/334) - Migration from the Play Core Java
+
 - v1.7.3
   - [PR #315](https://github.com/pushandplay/cordova-plugin-apprate/pull/315) - Fix error in IOS 17 "Call must be made on main thread" in launchAppStore method
   - [PR #313](https://github.com/pushandplay/cordova-plugin-apprate/pull/313) - Improve French translations

--- a/README.md
+++ b/README.md
@@ -63,9 +63,9 @@ AppRate.setPreferences({
 - From github repository: `cordova plugin add https://github.com/pushandplay/cordova-plugin-apprate.git`
 - For phonegap build add the following to your config.xml: `<gap:plugin name="cordova-plugin-apprate" />`
 
-## Integrating Google Play Core
+## Integrating Play In-App Reviews Library
 
-To set up Google Play Core version, you can use PLAY_CORE_VERSION parameter (with `1.+` value by default). It is useful in order to avoid conflicts with another plugins which use any other different version of Google Play Core.
+To set up Play In-App Reviews Library version, you can use PLAY_REVIEW_VERSION parameter (with `2.+` value by default). It is useful in order to avoid conflicts with another plugins which use any other different version of Play In-App Reviews Library. For Play In-App Reviews Library release notes please see https://developer.android.com/reference/com/google/android/play/core/release-notes-in_app_reviews
 
 ## Customization and usage
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-apprate",
-  "version": "1.7.4",
+  "version": "1.7.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/pushandplay/cordova-plugin-apprate"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-apprate",
-  "version": "1.7.3",
+  "version": "1.7.4",
   "repository": {
     "type": "git",
     "url": "https://github.com/pushandplay/cordova-plugin-apprate"

--- a/plugin.xml
+++ b/plugin.xml
@@ -19,7 +19,7 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-<plugin xmlns="http://cordova.apache.org/ns/plugins/1.0" id="cordova-plugin-apprate" version="1.7.3">
+<plugin xmlns="http://cordova.apache.org/ns/plugins/1.0" id="cordova-plugin-apprate" version="1.7.4">
     <name>AppRate</name>
     <description>This plugin provides "Rate This App" functionality to your Cordova/Phonegap application</description>
     <author email="hello@pushandplay.ru" href="http://pushandplay.ru">pushandplay</author>
@@ -50,8 +50,8 @@ under the License.
     </js-module>
 
     <platform name="android">
-        <preference name="PLAY_CORE_VERSION" default="1.+"/>
-        <framework src="com.google.android.play:core:$PLAY_CORE_VERSION" />
+        <preference name="PLAY_REVIEW_VERSION" default="2.+" />
+        <framework src="com.google.android.play:review:$PLAY_REVIEW_VERSION" />
         <source-file src="src/android/AppRate.java" target-dir="src/org/pushandplay/cordova/apprate"/>
 
         <config-file target="res/xml/config.xml" parent="/*">

--- a/plugin.xml
+++ b/plugin.xml
@@ -19,7 +19,7 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-<plugin xmlns="http://cordova.apache.org/ns/plugins/1.0" id="cordova-plugin-apprate" version="1.7.4">
+<plugin xmlns="http://cordova.apache.org/ns/plugins/1.0" id="cordova-plugin-apprate" version="1.7.3">
     <name>AppRate</name>
     <description>This plugin provides "Rate This App" functionality to your Cordova/Phonegap application</description>
     <author email="hello@pushandplay.ru" href="http://pushandplay.ru">pushandplay</author>

--- a/src/android/AppRate.java
+++ b/src/android/AppRate.java
@@ -15,7 +15,7 @@ import android.content.pm.ApplicationInfo;
 import com.google.android.play.core.review.ReviewInfo;
 import com.google.android.play.core.review.ReviewManager;
 import com.google.android.play.core.review.ReviewManagerFactory;
-import com.google.android.play.core.tasks.Task;
+import com.google.android.gms.tasks.Task;
 
 public class AppRate extends CordovaPlugin {
   @Override


### PR DESCRIPTION
Changes:
- migrate from the google play SDK to avoid warning from google play when the app is targeting SDK 34+ (targetSdkVersion). For more details please see https://github.com/pushandplay/cordova-plugin-apprate/issues/332